### PR TITLE
[Change] Update xinetd.conf.j2

### DIFF
--- a/templates/xinetd.conf.j2
+++ b/templates/xinetd.conf.j2
@@ -2,7 +2,7 @@
 
 defaults
 {
-{% for key, value in xinetd_defaults.iteritems()|sort %}
+{% for key, value in xinetd_defaults.items()|sort %}
 {%   if value is sameas true %}
     {{ key }} = yes
 {%   elif value is sameas false %}


### PR DESCRIPTION
made xinetd.conf.j2 template python 3 compatible - changed .iteritems() into .items()

Hello,
in python3 there is no .iteritems() anymore - so I've changed the template to be able to use it on newer installations.
Best regards, Sebastian