### PR TITLE
[Change] Update xinetd_d.j2

### DIFF
--- a/templates/xinetd_d.j2
+++ b/templates/xinetd_d.j2
@@ -2,7 +2,7 @@
 
 service {{ item }}
 {
-{% for key, value in xinetd_d[item].iteritems()|sort %}
+{% for key, value in xinetd_d[item].items()|sort %}
 {%   if value is sameas true %}
     {{ key }} = yes
 {%   elif value is sameas false %}


### PR DESCRIPTION
made also xinetd_d.j2 template python 3 compatible - changed .iteritems() into .items()

Hello, 
sorry I've overseen another occurrence  of .iteritems().
Thanks for merging .

Best regards, Sebastian